### PR TITLE
Add missing dependencies to MODULE.bazel

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -196,7 +196,12 @@ tasks:
     build_flags:
       - "--enable_bzlmod"
     build_targets:
+      - "//bindgen/3rdparty:bindgen"
+      - "//crate_universe:cargo_bazel_bin"
+      - "//proto/prost/private:prost_runtime"
       - "//tools/runfiles"
+      - "//util/import"
+      - "//wasm_bindgen/3rdparty:wasm_bindgen"
   ubuntu2004_clang:
     name: With Clang
     platform: ubuntu2004

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -186,6 +186,17 @@ tasks:
     test_targets: *default_windows_targets
     soft_fail: yes
     bazel: "rolling"
+  ubuntu2004_bzlmod_only:
+    name: With bzlmod
+    platform: ubuntu2004
+    # See https://bazel.build/external/migration#migration-process
+    # When WORKSPACE.bzlmod is provided, the workspace file is ignored.
+    shell_commands:
+      - "touch WORKSPACE.bzlmod"
+    build_flags:
+      - "--enable_bzlmod"
+    build_targets:
+      - "//tools/runfiles"
   ubuntu2004_clang:
     name: With Clang
     platform: ubuntu2004

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,19 +7,128 @@ module(
 
 print("WARNING: The rules_rust Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")  # buildifier: disable=print
 
-bazel_dep(name = "platforms", version = "0.0.8")
-bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.5.0",
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.8",
+)
+
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.9",
+)
+
+bazel_dep(
+    name = "rules_proto",
+    version = "5.3.0-21.7",
+)
+
 bazel_dep(
     name = "apple_support",
     version = "1.11.1",
     repo_name = "build_bazel_apple_support",
 )
 
+bazel_dep(
+    name = "protobuf",
+    version = "21.7",
+    repo_name = "com_google_protobuf",
+)
+
 internal_deps = use_extension("//rust/private:extensions.bzl", "internal_deps")
+
 use_repo(
     internal_deps,
+    "bazelci_rules",
+    "com_google_googleapis",
+    "cui",
+    "cui__anyhow-1.0.75",
+    "cui__cargo-lock-9.0.0",
+    "cui__cargo-platform-0.1.4",
+    "cui__cargo_metadata-0.18.1",
+    "cui__cargo_toml-0.17.1",
+    "cui__cfg-expr-0.15.5",
+    "cui__clap-4.3.11",
+    "cui__crates-index-2.2.0",
+    "cui__hex-0.4.3",
+    "cui__indoc-2.0.4",
+    "cui__itertools-0.11.0",
+    "cui__maplit-1.0.2",
+    "cui__normpath-1.1.1",
+    "cui__pathdiff-0.2.1",
+    "cui__regex-1.10.2",
+    "cui__semver-1.0.20",
+    "cui__serde-1.0.190",
+    "cui__serde_json-1.0.108",
+    "cui__serde_starlark-0.1.14",
+    "cui__sha2-0.10.8",
+    "cui__spectral-0.6.0",
+    "cui__tempfile-3.8.1",
+    "cui__tera-1.19.1",
+    "cui__textwrap-0.16.0",
+    "cui__toml-0.8.6",
+    "cui__tracing-0.1.40",
+    "cui__tracing-subscriber-0.3.17",
+    "generated_inputs_in_external_repo",
+    "libc",
+    "llvm-raw",
+    "rrra__anyhow-1.0.71",
+    "rrra__clap-4.3.11",
+    "rrra__env_logger-0.10.0",
+    "rrra__itertools-0.11.0",
+    "rrra__log-0.4.19",
+    "rrra__serde-1.0.171",
+    "rrra__serde_json-1.0.102",
+    "rules_rust_bindgen__bindgen-0.65.1",
+    "rules_rust_bindgen__bindgen-cli-0.65.1",
+    "rules_rust_bindgen__clang-sys-1.6.1",
+    "rules_rust_bindgen__clap-4.3.3",
+    "rules_rust_bindgen__clap_complete-4.3.1",
+    "rules_rust_bindgen__env_logger-0.10.0",
+    "rules_rust_prost",
+    "rules_rust_prost__h2-0.3.19",
+    "rules_rust_prost__heck",
+    "rules_rust_prost__prost-0.11.9",
+    "rules_rust_prost__prost-types-0.11.9",
+    "rules_rust_prost__protoc-gen-prost-0.2.2",
+    "rules_rust_prost__protoc-gen-tonic-0.2.2",
+    "rules_rust_prost__tokio-1.28.2",
+    "rules_rust_prost__tokio-stream-0.1.14",
+    "rules_rust_prost__tonic-0.9.2",
+    "rules_rust_test_load_arbitrary_tool",
     "rules_rust_tinyjson",
+    "rules_rust_toolchain_test_target_json",
+    "rules_rust_util_import__aho-corasick-0.7.15",
+    "rules_rust_util_import__lazy_static-1.4.0",
+    "rules_rust_util_import__proc-macro2-1.0.33",
+    "rules_rust_util_import__quickcheck-1.0.3",
+    "rules_rust_util_import__quote-1.0.10",
+    "rules_rust_util_import__syn-1.0.82",
+    "rules_rust_wasm_bindgen__anyhow-1.0.71",
+    "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
+    "rules_rust_wasm_bindgen__diff-0.1.13",
+    "rules_rust_wasm_bindgen__docopt-1.1.1",
+    "rules_rust_wasm_bindgen__env_logger-0.8.4",
+    "rules_rust_wasm_bindgen__log-0.4.19",
+    "rules_rust_wasm_bindgen__predicates-1.0.8",
+    "rules_rust_wasm_bindgen__rayon-1.7.0",
+    "rules_rust_wasm_bindgen__rouille-3.6.2",
+    "rules_rust_wasm_bindgen__serde-1.0.171",
+    "rules_rust_wasm_bindgen__serde_derive-1.0.171",
+    "rules_rust_wasm_bindgen__serde_json-1.0.102",
+    "rules_rust_wasm_bindgen__tempfile-3.6.0",
+    "rules_rust_wasm_bindgen__ureq-2.8.0",
+    "rules_rust_wasm_bindgen__walrus-0.19.0",
+    "rules_rust_wasm_bindgen__wasm-bindgen-0.2.88",
+    "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.88",
+    "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.88",
+    "rules_rust_wasm_bindgen__wasmparser-0.102.0",
+    "rules_rust_wasm_bindgen__wasmprinter-0.2.60",
+    "rules_rust_wasm_bindgen_cli",
 )
 
 rust = use_extension("//rust:extensions.bzl", "rust")
@@ -28,6 +137,7 @@ rust = use_extension("//rust:extensions.bzl", "rust")
 # Register it as a dev dependency so that we don't force this toolchain on
 # downstream users.
 rust.toolchain(edition = "2021")
+
 use_repo(rust, "rust_toolchains")
 
 register_toolchains(
@@ -38,4 +148,5 @@ register_toolchains(
 use_repo(rust, "rust_host_tools")
 
 cargo_bazel_bootstrap = use_extension("//crate_universe/private/module_extensions:cargo_bazel_bootstrap.bzl", "cargo_bazel_bootstrap")
+
 use_repo(cargo_bazel_bootstrap, "cargo_bazel_bootstrap")

--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -38,9 +38,10 @@ def rust_bindgen_dependencies():
         ],
     )
 
+    bindgen_name = "rules_rust_bindgen__bindgen-cli-{}".format(BINDGEN_VERSION)
     maybe(
         http_archive,
-        name = "rules_rust_bindgen__bindgen-cli-{}".format(BINDGEN_VERSION),
+        name = bindgen_name,
         sha256 = "33373a4e0ec8b6fa2654e0c941ad16631b0d564cfd20e7e4b3db4c5b28f4a237",
         type = "tar.gz",
         urls = ["https://crates.io/api/v1/crates/bindgen-cli/{}/download".format(BINDGEN_VERSION)],
@@ -48,7 +49,12 @@ def rust_bindgen_dependencies():
         build_file = Label("//bindgen/3rdparty:BUILD.bindgen-cli.bazel"),
     )
 
-    crate_repositories()
+    direct_deps = [
+        struct(repo = "llvm-raw", is_dev_dep = False),
+        struct(repo = bindgen_name, is_dev_dep = False),
+    ]
+    direct_deps.extend(crate_repositories())
+    return direct_deps
 
 # buildifier: disable=unnamed-macro
 def rust_bindgen_register_toolchains(register_toolchains = True):

--- a/crate_universe/repositories.bzl
+++ b/crate_universe/repositories.bzl
@@ -20,7 +20,8 @@ def crate_universe_dependencies(rust_version = rust_common.default_version, boot
     if bootstrap:
         cargo_bazel_bootstrap(rust_version = rust_version, **kwargs)
 
-    _vendor_crate_repositories()
+    direct_deps = _vendor_crate_repositories()
 
     crates_vendor_deps()
     cross_installer_deps()
+    return direct_deps

--- a/proto/prost/private/repositories.bzl
+++ b/proto/prost/private/repositories.bzl
@@ -3,11 +3,12 @@
 load("//proto/prost:repositories.bzl", _rust_prost_dependencies = "rust_prost_dependencies")
 load("//proto/prost/private/3rdparty/crates:crates.bzl", "crate_repositories")
 
-def rust_prost_dependencies():
+def rust_prost_dependencies(bzlmod = False):
     """Prost repository dependencies."""
-    crate_repositories()
+    direct_deps = crate_repositories()
 
-    _rust_prost_dependencies()
+    direct_deps.extend(_rust_prost_dependencies(bzlmod = bzlmod))
+    return direct_deps
 
 # buildifier: disable=unnamed-macro
 def rust_prost_register_toolchains(register_toolchains = True):

--- a/proto/prost/repositories.bzl
+++ b/proto/prost/repositories.bzl
@@ -3,25 +3,26 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-def rust_prost_dependencies():
-    maybe(
-        http_archive,
-        name = "rules_proto",
-        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-        strip_prefix = "rules_proto-5.3.0-21.7",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-        ],
-    )
+def rust_prost_dependencies(bzlmod = False):
+    if not bzlmod:
+        maybe(
+            http_archive,
+            name = "rules_proto",
+            sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+            strip_prefix = "rules_proto-5.3.0-21.7",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+                "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+            ],
+        )
 
-    maybe(
-        http_archive,
-        name = "com_google_protobuf",
-        sha256 = "52b6160ae9266630adb5e96a9fc645215336371a740e87d411bfb63ea2f268a0",
-        strip_prefix = "protobuf-3.18.0",
-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.18.0/protobuf-all-3.18.0.tar.gz"],
-    )
+        maybe(
+            http_archive,
+            name = "com_google_protobuf",
+            sha256 = "52b6160ae9266630adb5e96a9fc645215336371a740e87d411bfb63ea2f268a0",
+            strip_prefix = "protobuf-3.18.0",
+            urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.18.0/protobuf-all-3.18.0.tar.gz"],
+        )
 
     maybe(
         http_archive,
@@ -32,3 +33,6 @@ def rust_prost_dependencies():
         strip_prefix = "heck-0.4.1",
         build_file = Label("@rules_rust//proto/prost/private/3rdparty/crates:BUILD.heck-0.4.1.bazel"),
     )
+    return [
+        struct(repo = "rules_rust_prost__heck", is_dev_dep = False),
+    ]

--- a/rust/private/extensions.bzl
+++ b/rust/private/extensions.bzl
@@ -1,10 +1,47 @@
 """Bzlmod module extensions that are only used internally"""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//bindgen:repositories.bzl", "rust_bindgen_dependencies")
+load("//crate_universe:repositories.bzl", "crate_universe_dependencies")
+load("//proto/prost/private:repositories.bzl", "rust_prost_dependencies")
 load("//rust/private:repository_utils.bzl", "TINYJSON_KWARGS")
+load("//test:deps.bzl", "rules_rust_test_deps")
+load("//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
+load("//util/import:deps.bzl", "import_deps")
+load("//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_dependencies")
 
-def _internal_deps_impl(_module_ctx):
+def _internal_deps_impl(module_ctx):
+    # This should contain the subset of WORKSPACE.bazel that defines
+    # repositories.
+
+    # We don't want rules_rust_dependencies, as they contain things like
+    # rules_cc, which is contained in the BCR.
+    direct_deps = [struct(repo = "rules_rust_tinyjson", is_dev_dep = False)]
     http_archive(**TINYJSON_KWARGS)
+
+    direct_deps.extend(crate_universe_dependencies())
+    direct_deps.extend(rust_prost_dependencies(bzlmod = True))
+    direct_deps.extend(rust_bindgen_dependencies())
+    direct_deps.extend(rust_analyzer_dependencies())
+    direct_deps.extend(import_deps())
+    direct_deps.extend(rust_wasm_bindgen_dependencies())
+    direct_deps.extend(rules_rust_test_deps())
+
+    http_archive(
+        name = "bazelci_rules",
+        sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+        strip_prefix = "bazelci_rules-1.0.0",
+        url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
+    )
+    direct_deps.append(struct(repo = "bazelci_rules", is_dev_dep = True))
+
+    # is_dev_dep is ignored here. It's not relevant for internal_deps, as dev
+    # dependencies are only relevant for module extensions that can be used
+    # by other MODULES.
+    return module_ctx.extension_metadata(
+        root_module_direct_deps = [repo.repo for repo in direct_deps],
+        root_module_direct_dev_deps = [],
+    )
 
 internal_deps = module_extension(
     doc = "Dependencies for rules_rust",

--- a/test/deps.bzl
+++ b/test/deps.bzl
@@ -27,9 +27,8 @@ rust_library(
 def rules_rust_test_deps():
     """Load dependencies for rules_rust tests"""
 
-    load_arbitrary_tool_test()
-
-    generated_inputs_in_external_repo()
+    direct_deps = load_arbitrary_tool_test()
+    direct_deps.extend(generated_inputs_in_external_repo())
 
     maybe(
         http_archive,
@@ -58,3 +57,11 @@ def rules_rust_test_deps():
         strip_prefix = "googleapis-18becb1d1426feb7399db144d7beeb3284f1ccb0",
         sha256 = "b8c487191eb942361af905e40172644eab490190e717c3d09bf83e87f3994fff",
     )
+
+    direct_deps.extend([
+        struct(repo = "libc", is_dev_dep = True),
+        struct(repo = "rules_rust_toolchain_test_target_json", is_dev_dep = True),
+        struct(repo = "com_google_googleapis", is_dev_dep = True),
+    ])
+
+    return direct_deps

--- a/test/generated_inputs/external_repo.bzl
+++ b/test/generated_inputs/external_repo.bzl
@@ -62,3 +62,4 @@ def generated_inputs_in_external_repo():
     _generated_inputs_in_external_repo(
         name = "generated_inputs_in_external_repo",
     )
+    return [struct(repo = "generated_inputs_in_external_repo", is_dev_dep = True)]

--- a/test/load_arbitrary_tool/load_arbitrary_tool_test.bzl
+++ b/test/load_arbitrary_tool/load_arbitrary_tool_test.bzl
@@ -37,3 +37,4 @@ def load_arbitrary_tool_test():
     _load_arbitrary_tool_test(
         name = "rules_rust_test_load_arbitrary_tool",
     )
+    return [struct(repo = "rules_rust_test_load_arbitrary_tool", is_dev_dep = True)]

--- a/tools/rust_analyzer/deps.bzl
+++ b/tools/rust_analyzer/deps.bzl
@@ -6,7 +6,7 @@ load("//tools/rust_analyzer/3rdparty/crates:defs.bzl", "crate_repositories")
 
 def rust_analyzer_dependencies():
     """Define dependencies of the `rust_analyzer` Bazel tools"""
-    crate_repositories()
+    return crate_repositories()
 
 # For legacy support
 gen_rust_project_dependencies = rust_analyzer_dependencies

--- a/util/import/deps.bzl
+++ b/util/import/deps.bzl
@@ -5,7 +5,7 @@ The dependencies for running the gen_rust_project binary.
 load("//util/import/3rdparty/crates:defs.bzl", "crate_repositories")
 
 def import_deps():
-    crate_repositories()
+    return crate_repositories()
 
 # For legacy support
 gen_rust_project_dependencies = import_deps

--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -27,6 +27,9 @@ def rust_wasm_bindgen_dependencies():
     [wb]: https://github.com/rustwasm/wasm-bindgen
     """
 
+    direct_deps = [
+        struct(repo = "rules_rust_wasm_bindgen_cli", is_dev_dep = False),
+    ]
     maybe(
         http_archive,
         name = "rules_rust_wasm_bindgen_cli",
@@ -39,7 +42,8 @@ def rust_wasm_bindgen_dependencies():
         patches = [Label("//wasm_bindgen/3rdparty/patches:resolver.patch")],
     )
 
-    crate_repositories()
+    direct_deps.extend(crate_repositories())
+    return direct_deps
 
 # buildifier: disable=unnamed-macro
 def rust_wasm_bindgen_register_toolchains(register_toolchains = True):


### PR DESCRIPTION
This PR:
* Ensures that the module extension knows which repo rules it generates
* Ensures that if you try and build it with an incorrect set of repo rules, bazel will output a fixup command.
* Adds the targets to presubmits to verify that there are no changes